### PR TITLE
upstream: evision now uses smallCamelCase

### DIFF
--- a/lib/nx_evision.ex
+++ b/lib/nx_evision.ex
@@ -42,10 +42,10 @@ defmodule NxEvision do
   def convert_nx_to_mat(binary, type, cols, rows, channels = 3, :RGB) do
     case OpenCV.Mat.from_binary(binary, type, cols, rows, channels) do
       {:ok, reference} ->
-        case OpenCV.cvtcolor(reference, OpenCV.cv_color_rgb2bgr()) do
+        case OpenCV.cvtColor(reference, OpenCV.cv_COLOR_RGB2BGR()) do
           {:ok, reference} -> {:ok, reference}
           {:error, reason} -> {:error, reason}
-          _ -> {:error, 'unknown error when cvtcolor'}
+          _ -> {:error, 'unknown error when cvtColor'}
         end
 
       {:error, reason} ->
@@ -59,10 +59,10 @@ defmodule NxEvision do
   def convert_nx_to_mat(binary, type, cols, rows, channels = 4, :RGBA) do
     case OpenCV.Mat.from_binary(binary, type, cols, rows, channels) do
       {:ok, reference} ->
-        case OpenCV.cvtcolor(reference, OpenCV.cv_color_rgba2bgra()) do
+        case OpenCV.cvtColor(reference, OpenCV.cv_COLOR_RGBA2BGRA()) do
           {:ok, reference} -> {:ok, reference}
           {:error, reason} -> {:error, reason}
-          _ -> {:error, 'unknown error when cvtcolor'}
+          _ -> {:error, 'unknown error when cvtColor'}
         end
 
       {:error, reason} ->
@@ -121,18 +121,18 @@ defmodule NxEvision do
   def convert_mat_to_nx(mat, :BGRA), do: convert_mat_to_nx(mat, :BGR)
 
   def convert_mat_to_nx(mat, :RGB) do
-    case OpenCV.cvtcolor(mat, OpenCV.cv_color_bgr2rgb()) do
+    case OpenCV.cvtColor(mat, OpenCV.cv_COLOR_BGR2RGB()) do
       {:ok, reference} -> convert_mat_to_nx(reference, :BGR)
       {:error, reason} -> {:error, reason}
-      _ -> {:error, "Unknown error when cvtcolor"}
+      _ -> {:error, "Unknown error when cvtColor"}
     end
   end
 
   def convert_mat_to_nx(mat, :RGBA) do
-    case OpenCV.cvtcolor(mat, OpenCV.cv_color_bgra2rgba()) do
+    case OpenCV.cvtColor(mat, OpenCV.cv_COLOR_BGRA2RGBA()) do
       {:ok, reference} -> convert_mat_to_nx(reference, :BGRA)
       {:error, reason} -> {:error, reason}
-      _ -> {:error, "Unknown error when cvtcolor"}
+      _ -> {:error, "Unknown error when cvtColor"}
     end
   end
 end


### PR DESCRIPTION
Hi, `evision` now uses **smallCamelCase** for almost all OpenCV function names to 

1. avoid converting abbreviations to lowercase spellings, which can be quite tricky sometimes.
2. make the APIs look similar to their corresponding C++/Python ones.
3. This could also help when the user wants to search for existing examples/usage online.